### PR TITLE
Aliases export is broken

### DIFF
--- a/lib/DBIx/Class/Candy.pm
+++ b/lib/DBIx/Class/Candy.pm
@@ -92,7 +92,7 @@ sub import {
          primary_column => $self->gen_primary_column($inheritor, $set_table),
          unique_column => $self->gen_unique_column($inheritor, $set_table),
          (map { $_ => $self->gen_proxy($inheritor, $set_table) } @methods, @custom_methods),
-         (map { $_ => $self->gen_rename_proxy($inheritor, $set_table, \%aliases, \%custom_aliases) }
+         (map { $_ => $self->gen_rename_proxy($inheritor, $set_table, %aliases, %custom_aliases) }
             keys %aliases, keys %custom_aliases),
       ],
       groups  => {
@@ -210,10 +210,10 @@ sub gen_has_column {
 }
 
 sub gen_rename_proxy {
-  my ($self, $inheritor, $set_table, $aliases, $custom_aliases) = @_;
+  my ($self, $inheritor, $set_table, %aliases) = @_;
   sub {
     my ($class, $name) = @_;
-    my $meth = $aliases->{$name} || $custom_aliases->{$name};
+    my $meth = $aliases{$name};
     my $i = $inheritor;
     sub { $set_table->(); $i->$meth(@_) }
   }


### PR DESCRIPTION
Calling of `export_method_aliases` function raises `Can't locate object method "" via package` error into `gen_rename_proxy` function.

In the lines below `$meth` is empty because `$custom_aliases` is empty:

```
sub {
    my ($class, $name) = @_;
    my $meth = $aliases->{$name} || $custom_aliases->{$name};
    my $i = $inheritor;
    sub { $set_table->(); $i->$meth(@_) }
}
```

`%custom_aliases` passed into `gen_rename_proxy` as ref `$custom_aliases` function and fall into closure. But after that it clears into `gen_INIT` so stays empty into closure.

```
# import()
%custom_aliases = %{$custom[1]};
...
$self->gen_rename_proxy($inheritor, $set_table, \%aliases, \%custom_aliases)
...
$self->gen_INIT($perl_version, \%custom_aliases, \@custom_methods, $inheritor),

# gen_INIT()
%$custom_aliases = ();
```
