### PR TITLE
Fix test to work on prove -lr

### DIFF
--- a/t/autotable.t
+++ b/t/autotable.t
@@ -29,7 +29,7 @@ subtest v1 => sub { # {{{
       exception {
          DBIx::Class::Candy->gen_table('MyApp::DB::Pal', 1)
       },
-      qr(^unrecognized naming scheme! at t[\\/]autotable\.t),
+      qr(^unrecognized naming scheme! at .*?t[\\/]autotable\.t),
       'unknown naming scheme'
    );
 };


### PR DESCRIPTION
The way `prove -lr` works you could end up with a "fuller" relative path:

```
rabbit@Ahasver:~/devel/dbic$ cpanm --look DBIx::Class::Candy
--> Working on DBIx::Class::Candy
Fetching http://www.cpan.org/authors/id/F/FR/FREW/DBIx-Class-Candy-0.005001.tar.gz ... OK
Entering /home/rabbit/.cpanm/work/1461929910.16724/DBIx-Class-Candy-0.005001 with /bin/bash
```

```
rabbit@Ahasver:~/.cpanm/work/1461929910.16724/DBIx-Class-Candy-0.005001$ prove -lr
./t/autotable.t .................... 
    #   Failed test 'unknown naming scheme'
    #   at ./t/autotable.t line 32.
    #                   'unrecognized naming scheme! at ./t/autotable.t line 30.
    # '
    #     doesn't match '(?^:^unrecognized naming scheme! at t[\\/]autotable\.t)'
    # Looks like you failed 1 test of 4.
./t/autotable.t .................... 1/? 
#   Failed test 'v1'
#   at ./t/autotable.t line 35.
# Looks like you failed 1 test of 2.
./t/autotable.t .................... Dubious, test returned 1 (wstat 256, 0x100)
Failed 1/2 subtests 
...
```

Also the lack of `/s` on the regex may trip you up on certain
"always stacktrace" environments, but that's sufficiently esoteric
that I didn't bother adding it.
